### PR TITLE
fix(server.cfg): ensure ox_lib before qb-core

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -40,8 +40,8 @@ ensure baseevents
 
 # QBCore & Extra stuff
 ensure ox_lib
-ensure ox_target
 ensure qb-core
+ensure ox_target
 ensure [ox]
 ensure [qb]
 ensure [standalone]

--- a/server.cfg
+++ b/server.cfg
@@ -39,9 +39,9 @@ ensure hardcap
 ensure baseevents
 
 # QBCore & Extra stuff
-ensure qb-core
 ensure ox_lib
 ensure ox_target
+ensure qb-core
 ensure [ox]
 ensure [qb]
 ensure [standalone]


### PR DESCRIPTION
Ensure ox_lib ~~& ox_target~~ before qb-core so that they can be used as dependencies.

Fixes Qbox-project/qb-core#18