### PR TITLE
feat(ox.cfg): add mechanic mats

### DIFF
--- a/ox.cfg
+++ b/ox.cfg
@@ -65,10 +65,13 @@ set inventory:vehicleloot [
 ]
 # Possible items that can be found in a dumpster
 set inventory:dumpsterloot [
-    ["mustard", 1, 1],
-    ["garbage", 1, 3],
-    ["money", 1, 10],
-    ["burger", 1, 1]
+    ["aluminum", 1, 5],
+    ["metalscrap", 1, 5],
+    ["iron", 1, 5],
+    ["steel", 1, 5],
+    ["glass", 1, 5],
+    ["rubber", 1, 5],
+    ["plastic", 1, 5]
 ]
 # Stashes will be wiped after remaining unchanged for the given time
 set inventory:clearstashes "6 MONTH"


### PR DESCRIPTION
## Description

- Adding the mats which appear by default in QBCore for mechanic currency and crafting.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
