### PR TITLE
fix(recipe/mugshot): Extract from sub-path, re-add LICENSE.MD/README.md

### DIFF
--- a/qbox.yaml
+++ b/qbox.yaml
@@ -102,9 +102,18 @@ tasks:
     src: ./tmp/illenium-appearance.zip
 
   - action: download_github
-    dest: ./resources/[standalone]
+    dest: ./resources/[standalone]/MugShotBase64
     ref: main
     src: https://github.com/BaziForYou/MugShotBase64
+    subpath: MugShotBase64
+
+  - action: download_file
+    url: https://raw.githubusercontent.com/BaziForYou/MugShotBase64/main/README.md
+    path: ./resources/[standalone]/MugShotBase64/README.md
+
+  - action: download_file
+    url: https://raw.githubusercontent.com/BaziForYou/MugShotBase64/main/LICENSE.md
+    path: ./resources/[standalone]/MugShotBase64/LICENSE.md
 
   - action: download_github
     dest: ./resources/[qbx]/qbx_idcard


### PR DESCRIPTION
## Description

When MugShotBase64 is pulled into the repo, the LICENSE.md and README.md files are placed into the [standalone] directory because MugShotBase64's resources are located in a subdirectory in the remote repo. 

This PR will download the sub-path and individually download the license and readme to keep it consistent with other resources and meet MIT license requirements of distributing the original author's license with the software.

**Previous structure:**
![image](https://github.com/Qbox-project/txAdminRecipe/assets/58707473/b25b7351-f6aa-4613-a9bc-df0465642b80)

**After PR:**
![image](https://github.com/Qbox-project/txAdminRecipe/assets/58707473/1bdc1a5c-fa3e-4dc7-93f1-282806bccd7b)


## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->
_**Recipe has been tested**_
- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
