### PR TITLE
fix: weathersync, carwash, fireworks, and binoculars

### DIFF
--- a/qbox.yaml
+++ b/qbox.yaml
@@ -117,7 +117,7 @@ tasks:
     url: https://raw.githubusercontent.com/BaziForYou/MugShotBase64/main/LICENSE.md
     path: ./resources/[standalone]/MugShotBase64/LICENSE.md
 
-  - action: download_github
+  - action: download_file
     dest: ./resources/[standalone]/Renewed-Weathersync
     ref: main
     src: https://github.com/Renewed-Scripts/Renewed-Weathersync/releases/latest/download/Renewed-Weathersync.zip
@@ -412,7 +412,7 @@ tasks:
     ref: main
     src: https://github.com/Qbox-project/qbx_idcard
 
-  - action: download_github
+  - action: download_file
     dest: ./resources/[qbx]/qbx_binoculars
     ref: main
     src: https://github.com/Qbox-project/qbx_binoculars/releases/latest/download/qbx_binoculars.zip

--- a/qbox.yaml
+++ b/qbox.yaml
@@ -118,9 +118,9 @@ tasks:
     path: ./resources/[standalone]/MugShotBase64/LICENSE.md
 
   - action: download_github
-    dest: ./resources/[qbx]/qbx_idcard
+    dest: ./resources/[standalone]/Renewed-Weathersync
     ref: main
-    src: https://github.com/Qbox-project/qbx_idcard
+    src: https://github.com/Renewed-Scripts/Renewed-Weathersync/releases/latest/download/Renewed-Weathersync.zip
 
     # VOICE
   - action: download_github
@@ -231,11 +231,6 @@ tasks:
     dest: ./resources/[qbx]/qbx_crypto
     ref: main
     src: https://github.com/qbox-project/qbx_crypto
-
-  - action: download_github
-    dest: ./resources/[standalone]/Renewed-Weathersync
-    ref: main
-    src: https://github.com/Renewed-Scripts/Renewed-Weathersync
 
   - action: download_github
     dest: ./resources/[qbx]/qbx_policejob
@@ -411,6 +406,26 @@ tasks:
     dest: ./resources/[qbx]/qbx_loading
     ref: main
     src: https://github.com/qbox-project/qbx_loading
+
+  - action: download_github
+    dest: ./resources/[qbx]/qbx_idcard
+    ref: main
+    src: https://github.com/Qbox-project/qbx_idcard
+
+  - action: download_github
+    dest: ./resources/[qbx]/qbx_binoculars
+    ref: main
+    src: https://github.com/Qbox-project/qbx_binoculars/releases/latest/download/qbx_binoculars.zip
+
+  - action: download_github
+    dest: ./resources/[qbx]/qbx_carwash
+    ref: main
+    src: https://github.com/Qbox-project/qbx_carwash
+
+  - action: download_github
+    dest: ./resources/[qbx]/qbx_fireworks
+    ref: main
+    src: https://github.com/Qbox-project/qbx_fireworks
 
   # OX
   - action: download_file

--- a/qbox.yaml
+++ b/qbox.yaml
@@ -118,9 +118,11 @@ tasks:
     path: ./resources/[standalone]/MugShotBase64/LICENSE.md
 
   - action: download_file
-    dest: ./resources/[standalone]/Renewed-Weathersync
-    ref: main
-    src: https://github.com/Renewed-Scripts/Renewed-Weathersync/releases/latest/download/Renewed-Weathersync.zip
+    path: ./tmp/Renewed-Weathersync.zip
+    url: https://github.com/Renewed-Scripts/Renewed-Weathersync/releases/latest/download/Renewed-Weathersync.zip
+  - action: unzip
+    dest: ./resources/[standalone]
+    src: ./tmp/Renewed-Weathersync.zip
 
     # VOICE
   - action: download_github
@@ -413,9 +415,11 @@ tasks:
     src: https://github.com/Qbox-project/qbx_idcard
 
   - action: download_file
-    dest: ./resources/[qbx]/qbx_binoculars
-    ref: main
-    src: https://github.com/Qbox-project/qbx_binoculars/releases/latest/download/qbx_binoculars.zip
+    path: ./tmp/qbx_binoculars.zip
+    url: https://github.com/Qbox-project/qbx_binoculars/releases/latest/download/qbx_binoculars.zip
+  - action: unzip
+    dest: ./resources/[qbx]
+    src: ./tmp/qbx_binoculars.zip
 
   - action: download_github
     dest: ./resources/[qbx]/qbx_carwash


### PR DESCRIPTION
## Description

Adds the Renewed-Weathersync properly, qbx_binoculars, qbx_carwash, and qbx_fireworks

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
