### PR TITLE
feat: remove skillbar and crypto

### DIFF
--- a/qbox-lean.yaml
+++ b/qbox-lean.yaml
@@ -223,6 +223,11 @@ tasks:
     src: https://github.com/qbox-project/qbx_phone
 
   - action: download_github
+    dest: ./resources/[qbx]/qbx_skillbar
+    ref: main
+    src: https://github.com/qbox-project/qbx_skillbar
+
+  - action: download_github
     dest: ./resources/[qbx]/qbx_smallresources
     ref: main
     src: https://github.com/qbox-project/qbx_smallresources

--- a/qbox.yaml
+++ b/qbox.yaml
@@ -290,6 +290,11 @@ tasks:
     src: https://github.com/qbox-project/qbx_spawn
 
   - action: download_github
+    dest: ./resources/[qbx]/qbx_skillbar
+    ref: main
+    src: https://github.com/qbox-project/qbx_skillbar
+
+  - action: download_github
     dest: ./resources/[qbx]/qbx_smallresources
     ref: main
     src: https://github.com/qbox-project/qbx_smallresources


### PR DESCRIPTION
## Description

Remove qbx_skillbar and qbx_crypto from the recipes as they have been archived

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
