### PR TITLE
fix(config/permissions): adds missing ox_lib permissions

### DIFF
--- a/permissions.cfg
+++ b/permissions.cfg
@@ -3,6 +3,12 @@ add_ace group.admin command allow # allow all commands
 # Resources
 add_ace resource.qbx_core command allow # Allow qbx_core to execute commands
 
+# Ox_lib
+add_ace resource.ox_lib command.add_ace allow
+add_ace resource.ox_lib command.remove_ace allow
+add_ace resource.ox_lib command.add_principal allow
+add_ace resource.ox_lib command.remove_principal allow
+
 # Ace Groups
 add_ace group.admin admin allow
 add_ace group.mod mod allow


### PR DESCRIPTION
## Description

Not sure why these weren't added before

https://overextended.dev/ox_lib#config

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ ] My pull request fits the contribution guidelines & code conventions.
