### PR TITLE
fix(npwd): correct version

### DIFF
--- a/qbox-lean.yaml
+++ b/qbox-lean.yaml
@@ -286,7 +286,7 @@ tasks:
     # NPWD
   - action: download_file
     path: ./tmp/npwd.zip
-    url: https://github.com/project-error/npwd/releases/download/latest/npwd.zip
+    url: https://github.com/project-error/npwd/releases/download/3.14.3/npwd.zip
   - action: unzip
     dest: ./resources/[npwd]/
     src: ./tmp/npwd.zip

--- a/qbox.yaml
+++ b/qbox.yaml
@@ -452,7 +452,7 @@ tasks:
     # NPWD
   - action: download_file
     path: ./tmp/npwd.zip
-    url: https://github.com/project-error/npwd/releases/download/latest/npwd.zip
+    url: https://github.com/project-error/npwd/releases/download/3.14.3/npwd.zip
   - action: unzip
     dest: ./resources/[npwd]/
     src: ./tmp/npwd.zip


### PR DESCRIPTION
## Description

When using `releases/download/latest/npwd.zip`, it downloads version `v1.8.2` instead of the actual latest version which is causing people to have issues upon downloading the recipe. I've just gone ahead and put the latest stable version in and we can then update this as we see fit.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ ] My pull request fits the contribution guidelines & code conventions.
