### PR TITLE
fix(qbox.sql): correct ox_doorlock syntax

### DIFF
--- a/qbox.sql
+++ b/qbox.sql
@@ -261,12 +261,12 @@ CREATE TABLE IF NOT EXISTS `ox_doorlock` (
 ) ENGINE=InnoDB;
 
 INSERT INTO `ox_doorlock` (`id`, `name`, `data`) VALUES
-	(1, 'vangelico_jewellery', '{"maxDistance":2,"groups":{"police":0},"doors":[{"model":1425919976,"coords":{"x":-631.9553833007813,"y":-236.33326721191407,"z":38.2065315246582},"heading":306},{"model":9467943,"coords":{"x":-630.426513671875,"y":-238.4375457763672,"z":38.2065315246582},"heading":306}],"state":1,"coords":{"x":-631.19091796875,"y":-237.38540649414063,"z":38.2065315246582},"hideUi":true}');
-    (2, 'BigBankThermite1', '{\"heading\":160,\"doors\":false,\"maxDistance\":2,\"hideUi\":true,\"groups\":{\"police\":0},\"coords\":{\"x\":251.85757446289063,\"y\":221.0654754638672,\"z\":101.83240509033203},\"model\":-1508355822,\"state\":1,\"autolock\":1800}'),
-    (3, 'BigBankThermite2', '{\"coords\":{\"x\":261.3004150390625,\"y\":214.50514221191407,\"z\":101.83240509033203},\"autolock\":1800,\"maxDistance\":2,\"groups\":{\"police\":0},\"model\":-1508355822,\"doors\":false,\"hideUi\":true,\"heading\":250,\"state\":1}'),
-    (4, 'BigBankLPDoor', '{\"coords\":{\"x\":256.3115539550781,\"y\":220.65785217285157,\"z\":106.42955780029297},\"autolock\":1800,\"maxDistance\":2,\"model\":-222270721,\"doors\":false,\"lockpick\":true,\"hideUi\":true,\"heading\":340,\"state\":1,\"lockpickDifficulty\":[\"hard\"]}'),
-    (5, 'PaletoThermiteDoor', '{\"coords\":{\"x\":-106.47130584716797,\"y\":6476.15771484375,\"z\":31.95479965209961},\"autolock\":1800,\"maxDistance\":2,\"groups\":{\"police\":0},\"model\":1309269072,\"doors\":false,\"hideUi\":true,\"heading\":315,\"state\":1}'),
-    (6, 'BigBankRedCardDoor', '{\"coords\":{\"x\":262.1980895996094,\"y\":222.518798828125,\"z\":106.42955780029297},\"autolock\":1800,\"maxDistance\":2,\"groups\":{\"police\":0},\"model\":746855201,\"doors\":false,\"hideUi\":true,\"heading\":250,\"state\":1}');
+	(1, 'vangelico_jewellery', '{"maxDistance":2,"groups":{"police":0},"doors":[{"model":1425919976,"coords":{"x":-631.9553833007813,"y":-236.33326721191407,"z":38.2065315246582},"heading":306},{"model":9467943,"coords":{"x":-630.426513671875,"y":-238.4375457763672,"z":38.2065315246582},"heading":306}],"state":1,"coords":{"x":-631.19091796875,"y":-237.38540649414063,"z":38.2065315246582},"hideUi":true}'),
+    (2, 'BigBankThermite1', '{"heading":160,"doors":false,"maxDistance":2,"hideUi":true,"groups":{"police":0},"coords":{"x":251.85757446289063,"y":221.0654754638672,"z":101.83240509033203},"model":-1508355822,"state":1,"autolock":1800}'),
+    (3, 'BigBankThermite2', '{"coords":{"x":261.3004150390625,"y":214.50514221191407,"z":101.83240509033203},"autolock":1800,"maxDistance":2,"groups":{"police":0},"model":-1508355822,"doors":false,"hideUi":true,"heading":250,"state":1}'),
+    (4, 'BigBankLPDoor', '{"coords":{"x":256.3115539550781,"y":220.65785217285157,"z":106.42955780029297},"autolock":1800,"maxDistance":2,"model":-222270721,"doors":false,"lockpick":true,"hideUi":true,"heading":340,"state":1,"lockpickDifficulty":["hard"]}'),
+    (5, 'PaletoThermiteDoor', '{"coords":{"x":-106.47130584716797,"y":6476.15771484375,"z":31.95479965209961},"autolock":1800,"maxDistance":2,"groups":{"police":0},"model":1309269072,"doors":false,"hideUi":true,"heading":315,"state":1}'),
+    (6, 'BigBankRedCardDoor', '{"coords":{"x":262.1980895996094,"y":222.518798828125,"z":106.42955780029297},"autolock":1800,"maxDistance":2,"groups":{"police":0},"model":746855201,"doors":false,"hideUi":true,"heading":250,"state":1}');
 
 CREATE TABLE IF NOT EXISTS `bank_accounts_new` (
   `id` varchar(50) NOT NULL,


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
fixes incorrect syntax with sql

![image](https://github.com/Qbox-project/txAdminRecipe/assets/769465/fcc8e239-459e-4f60-8852-b335fe5ece10)


## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
