### PR TITLE
fix: use ox_fuel v1.4.0

### DIFF
--- a/qbox-lean.yaml
+++ b/qbox-lean.yaml
@@ -280,7 +280,7 @@ tasks:
 
   - action: download_github
     dest: ./resources/[ox]/ox_fuel
-    ref: main
+    ref: v1.4.0
     src: https://github.com/overextended/ox_fuel
 
     # NPWD

--- a/qbox.yaml
+++ b/qbox.yaml
@@ -441,7 +441,7 @@ tasks:
 
   - action: download_github
     dest: ./resources/[ox]/ox_fuel
-    ref: main
+    ref: v1.4.0
     src: https://github.com/overextended/ox_fuel
 
     # NPWD


### PR DESCRIPTION
## Description

Revert to [ox_lib v1.4.0](https://github.com/overextended/ox_fuel/releases/tag/v1.4.0) since the main branch [uses recently added natives](https://github.com/overextended/ox_fuel/commit/616aa4b3c236849d86b7995f751fa4a5b57230d5) that only work on FiveM builds 8201+.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
