### PR TITLE
feat(server.cfg): enable `loadscreen:externalShutdown`

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -46,6 +46,7 @@ set SCREENSHOT_BASIC_TOKEN insert_token
 set NPWD_AUDIO_TOKEN insert_token
 
 # loadscreen config
+setr loadscreen:externalShutdown true
 set loadscreen:primaryColor "#f1e542"
 set loadscreen:shadowColor "#1a18077f"
 


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

This enables the `loadscreen:externalShutdown` convar, which lets the loadscreen know to not shutdown automatically, since qbx_core can shut it down by itself.

This lets the loading screen run until the multicharacter menu.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
