### PR TITLE
feat(server.cfg): stop basic-gamemode

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -55,7 +55,7 @@ ensure mapmanager
 ensure chat
 ensure spawnmanager
 ensure sessionmanager
-ensure basic-gamemode
+stop basic-gamemode
 ensure hardcap
 ensure baseevents
 


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
basic-gamemode causes the bridge scene to appear. Our provided loading screen supports external shutdown and prevents this from popping up leading to a more seamless experience.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
