### PR TITLE
fix(sql): enforce collation on name column

### DIFF
--- a/qbox.sql
+++ b/qbox.sql
@@ -138,7 +138,7 @@ CREATE TABLE IF NOT EXISTS `players` (
 
 ALTER TABLE `players`
 ADD IF NOT EXISTS `last_logged_out` timestamp NULL DEFAULT NULL AFTER `last_updated`,
-MODIFY COLUMN `citizenid` varchar(50) NOT NULL COLLATE utf8mb4_unicode_ci;
+MODIFY COLUMN `name` varchar(50) NOT NULL COLLATE utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `playerskins` (
   `id` int(11) NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
CitizenID is a generated field that has a charset of A-Z 0-9. Forcing this to a certain collation is counterintuitive as it doesn't support unicode characters. The issue that was supposed to be resolved by this is for the `name` field being unpopulated due to players with unicode characters in their name within the fivem client. This corrects that issue as well as streamlining qb-core users migrating to qbx_core.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
