### PR TITLE
fix(sql): remove unneeded job account inserts

### DIFF
--- a/qbox.sql
+++ b/qbox.sql
@@ -274,19 +274,6 @@ CREATE TABLE IF NOT EXISTS `bank_accounts_new` (
   PRIMARY KEY (`id`)
 ) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-INSERT INTO `bank_accounts_new` (`id`, `amount`, `transactions`, `auth`, `isFrozen`, `creator`) VALUES
-	('ambulance', 0, '[]', '[]', 0, NULL),
-	('cardealer', 0, '[]', '[]', 0, NULL),
-	('mechanic', 0, '[]', '[]', 0, NULL),
-	('police', 0, '[]', '[]', 0, NULL),
-	('realestate', 0, '[]', '[]', 0, NULL),
-	('lostmc', 0, '[]', '[]', 0, NULL),
-	('ballas', 0, '[]', '[]', 0, NULL),
-	('vagos', 0, '[]', '[]', 0, NULL),
-	('cartel', 0, '[]', '[]', 0, NULL),
-	('families', 0, '[]', '[]', 0, NULL),
-	('triads', 0, '[]', '[]', 0, NULL);
-
 CREATE TABLE IF NOT EXISTS `player_transactions` (
   `id` varchar(50) NOT NULL,
   `isFrozen` int(11) DEFAULT 0,


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Renewed-Banking v2.1 automatically builds the society accounts making this insert unneeded as it will be created on first start.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
