### PR TITLE
refactor: use chat from fivem system resources

### DIFF
--- a/qbox-lean.yaml
+++ b/qbox-lean.yaml
@@ -38,6 +38,8 @@ tasks:
     src: https://github.com/citizenfx/cfx-server-data
     subpath: resources
     dest: ./resources/[cfx-default]
+  - action: remove_path
+    path: ./resources/[cfx-default]/[gameplay]/chat
 
   - action: download_github
     dest: ./resources/[standalone]/bob74_ipl

--- a/qbox-stable.yaml
+++ b/qbox-stable.yaml
@@ -38,6 +38,8 @@ tasks:
     src: https://github.com/citizenfx/cfx-server-data
     subpath: resources
     dest: ./resources/[cfx-default]
+  - action: remove_path
+    path: ./resources/[cfx-default]/[gameplay]/chat
 
   - action: download_github
     dest: ./resources/[standalone]/bob74_ipl

--- a/qbox.yaml
+++ b/qbox.yaml
@@ -38,6 +38,8 @@ tasks:
     src: https://github.com/citizenfx/cfx-server-data
     subpath: resources
     dest: ./resources/[cfx-default]
+  - action: remove_path
+    path: ./resources/[cfx-default]/[gameplay]/chat
 
   - action: download_github
     dest: ./resources/[standalone]/bob74_ipl

--- a/server.cfg
+++ b/server.cfg
@@ -12,6 +12,7 @@ sets sv_projectDesc "{{recipeDescription}}"
 sets locale "en-US"
 load_server_icon myLogo.png
 set sv_enforceGameBuild 3258
+set resources_useSystemChat true
 set mysql_connection_string "{{dbConnectionString}}"
 
 # Voice config


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Use `chat` from FiveM's built-in [`system-resources`](https://github.com/citizenfx/fivem/tree/0776d79840adc87a90786a4ad9ad9b12dacb8886/ext/system-resources) to abide by the newest txAdmin [recipe guidelines](https://github.com/tabarra/txAdmin-recipes/commit/2b8b6bbd88e69aed443cef2b934a279079f3d7bf).
Tested fine with Lean recipe.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
