### PR TITLE
refactor: replace prison and vehiclefailure

### DIFF
--- a/qbox-lean.yaml
+++ b/qbox-lean.yaml
@@ -165,11 +165,6 @@ tasks:
     src: https://github.com/qbox-project/qbx_vehicleshop
 
   - action: download_github
-    dest: ./resources/[qbx]/qbx_prison
-    ref: main
-    src: https://github.com/qbox-project/qbx_prison
-
-  - action: download_github
     dest: ./resources/[qbx]/qbx_hud
     ref: main
     src: https://github.com/qbox-project/qbx_hud
@@ -203,11 +198,6 @@ tasks:
     ref: main
     src: https://github.com/qbox-project/qbx_medical
 
-  - action: download_github
-    dest: ./resources/[qbx]/qbx_vehiclefailure
-    ref: main
-    src: https://github.com/qbox-project/qbx_vehiclefailure
-
   - action: waste_time # prevent github throttling
     seconds: 10
 
@@ -222,6 +212,22 @@ tasks:
   - action: unzip
     dest: ./resources/[standalone]
     src: ./tmp/Renewed-Weathersync.zip
+
+    # replaces qbx_prison
+  - action: download_file
+    path: ./tmp/xt-prison.zip
+    url: https://github.com/xT-Development/xt-prison/releases/latest/download/xt-prison.zip
+  - action: unzip
+    dest: ./resources/[standalone]
+    src: ./tmp/xt-prison.zip
+
+    # replaces qbx_vehiclefailure
+  - action: download_file
+    path: ./tmp/vehiclehandler.zip
+    url: https://github.com/QuantumMalice/vehiclehandler/releases/latest/download/vehiclehandler.zip
+  - action: unzip
+    dest: ./resources/[standalone]
+    src: ./tmp/vehiclehandler.zip
 
   - action: download_github
     dest: ./resources/[qbx]/qbx_police

--- a/qbox-stable.yaml
+++ b/qbox-stable.yaml
@@ -178,6 +178,22 @@ tasks:
     dest: ./resources/[standalone]
     src: ./tmp/Renewed-Weathersync.zip
 
+    # replaces qbx_prison
+  - action: download_file
+    path: ./tmp/xt-prison.zip
+    url: https://github.com/xT-Development/xt-prison/releases/latest/download/xt-prison.zip
+  - action: unzip
+    dest: ./resources/[standalone]
+    src: ./tmp/xt-prison.zip
+
+    # replaces qbx_vehiclefailure
+  - action: download_file
+    path: ./tmp/vehiclehandler.zip
+    url: https://github.com/QuantumMalice/vehiclehandler/releases/latest/download/vehiclehandler.zip
+  - action: unzip
+    dest: ./resources/[standalone]
+    src: ./tmp/vehiclehandler.zip
+
   - action: download_file
     path: ./tmp/qbx_vehicles.zip
     url: https://github.com/qbox-project/qbx_vehicles/releases/latest/download/qbx_vehicles.zip

--- a/qbox.yaml
+++ b/qbox.yaml
@@ -111,6 +111,22 @@ tasks:
     dest: ./resources/[standalone]
     src: ./tmp/Renewed-Weathersync.zip
 
+    # replaces qbx_prison
+  - action: download_file
+    path: ./tmp/xt-prison.zip
+    url: https://github.com/xT-Development/xt-prison/releases/latest/download/xt-prison.zip
+  - action: unzip
+    dest: ./resources/[standalone]
+    src: ./tmp/xt-prison.zip
+
+    # replaces qbx_vehiclefailure
+  - action: download_file
+    path: ./tmp/vehiclehandler.zip
+    url: https://github.com/QuantumMalice/vehiclehandler/releases/latest/download/vehiclehandler.zip
+  - action: unzip
+    dest: ./resources/[standalone]
+    src: ./tmp/vehiclehandler.zip
+
   - action: download_file
     path: ./tmp/loadscreen.zip
     url: https://github.com/D4isDAVID/loadscreen/releases/latest/download/loadscreen.zip
@@ -170,11 +186,6 @@ tasks:
     src: https://github.com/qbox-project/qbx_houserobbery
 
   - action: download_github
-    dest: ./resources/[qbx]/qbx_prison
-    ref: main
-    src: https://github.com/qbox-project/qbx_prison
-
-  - action: download_github
     dest: ./resources/[qbx]/qbx_hud
     ref: main
     src: https://github.com/qbox-project/qbx_hud
@@ -217,11 +228,6 @@ tasks:
     dest: ./resources/[qbx]/qbx_medical
     ref: main
     src: https://github.com/qbox-project/qbx_medical
-
-  - action: download_github
-    dest: ./resources/[qbx]/qbx_vehiclefailure
-    ref: main
-    src: https://github.com/qbox-project/qbx_vehiclefailure
 
   - action: waste_time # prevent github throttling
     seconds: 10


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Replaces qbx_vehiclefailure and qbx_prison with [QuantumMalice/vehiclehandler](https://github.com/QuantumMalice/vehiclehandler) and [xT-Development/xt-prison](https://github.com/xT-Development/xt-prison) respectively. Additionally adds these to the stable release.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
