### PR TITLE
fix: add SQL for qbx_weed

### DIFF
--- a/qbox.sql
+++ b/qbox.sql
@@ -306,3 +306,16 @@ CREATE TABLE IF NOT EXISTS `properties` (
 	FOREIGN KEY (owner) REFERENCES `players` (`citizenid`),
 	PRIMARY KEY (id)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `weed_plants` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `property` varchar(30) NULL,
+  `stage` tinyint NOT NULL DEFAULT 1,
+  `sort` varchar(30) NOT NULL,
+  `gender` enum('male', 'female') NOT NULL,
+  `food` tinyint NOT NULL DEFAULT 100,
+  `health` tinyint NOT NULL DEFAULT 100,
+  `stageProgress` tinyint NOT NULL DEFAULT 0,
+  `coords` tinytext NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Description

When creating a fresh server, qbx_weed sql isn't imported by default and error "Table 'qboxproject_e321e5.weed_plants' doesn't exist" is being thrown inside server console.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
