### PR TITLE
refactor(server.cfg): revert to game build 3095

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -11,7 +11,7 @@ sets sv_projectName "[{{recipeName}}] {{serverName}}"
 sets sv_projectDesc "{{recipeDescription}}"
 sets locale "en-US"
 load_server_icon myLogo.png
-set sv_enforceGameBuild 3258
+set sv_enforceGameBuild 3095
 set resources_useSystemChat true
 set mysql_connection_string "{{dbConnectionString}}"
 


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Reverts the server's default game build to 3095 as per txAdmin's [recipe guidelines](https://github.com/tabarra/txAdmin-recipes?tab=readme-ov-file#recipe-making-guidelines-and-best-practices):
> Set the game build to the same in the CFX Default recipes

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
