### PR TITLE
Update server.cfg

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -11,7 +11,7 @@ sets sv_projectName "[{{recipeName}}] {{serverName}}"
 sets sv_projectDesc "{{recipeDescription}}"
 sets locale "en-US"
 load_server_icon myLogo.png
-set sv_enforceGameBuild 3258
+set sv_enforceGameBuild 3095
 set resources_useSystemChat true
 set mysql_connection_string "{{dbConnectionString}}"
 


### PR DESCRIPTION
Game build 3258 is not stable at all, putting this as default in the current state of that build is very irresponsible.

My PR changes the default game build that the server will use, game build 3258 is totally not stable and does not belong in any framework at the moment as "default".

Does it fix an issue?

Yes, the current game build is known for causing crashes randomly, Cfx is still investigating this.

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.