### PR TITLE
Removed convar from server.cfg

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -14,7 +14,6 @@ load_server_icon myLogo.png
 set sv_enforceGameBuild 3095
 set resources_useSystemChat true
 set mysql_connection_string "{{dbConnectionString}}"
-set sv_experimentalNetGameEventHandler false
 
 # Voice config
 setr voice_useNativeAudio true


### PR DESCRIPTION
Removed sv_experimentalNetGameEventHandler convar as this is no longer required in newer FXServer builds

According to the FiveM code, this change was reverted:

https://github.com/citizenfx/fivem/commit/4d8d2f696de64414b430324d072300c5b18f1f97

My pull request removes a console variable in the server.cfg file 

- [x] My pull request fits the contribution guidelines & code conventions.
