### PR TITLE
tweak: sv_enableNetEventReassembly default value

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -150,9 +150,9 @@ setr profile_skfx 1 # 0: disables kill screen effects 1: enables them
 set sv_netHttp2 false
 
 # The following convars all have something to do with the *_LATENT_* natives. These natives were never recommended to be used and were flawed under the hood. These convars should fix that.
-# Default: false
+# Default: true
 # Type: boolean
-setr sv_enableNetEventReassembly false
+setr sv_enableNetEventReassembly true
 # If the above is set to true, you can use one of these 2 convars to set the amount of pending events to be reassembled.
 # Default: 100
 # Type: int


### PR DESCRIPTION
Apparently this is [true by default](https://github.com/citizenfx/fivem/blob/37b6ac991a114088e744cf900cc711dc655b95ff/code/components/citizen-server-impl/src/ServerResources.cpp#L417). I don't know where I got false from. Also recommend to be used by txAdmin [here](https://github.com/tabarra/txAdmin/blob/8cbc767aa24e614fe2dc801810cb3ea58df282fd/resource/menu/server/sv_webpipe.lua#L25). So we don't wanna ship new servers with this set to false.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
