### PR TITLE
fix(items): conflicts with qbx_medical

### DIFF
--- a/items.lua
+++ b/items.lua
@@ -56,12 +56,6 @@ return {
     ['bandage'] = {
         label = 'Bandage',
         weight = 115,
-        client = {
-            anim = { dict = 'missheistdockssetup1clipboard@idle_a', clip = 'idle_a', flag = 49 },
-            prop = { model = `prop_rolled_sock_02`, pos = vec3(-0.14, -0.14, -0.08), rot = vec3(-50.0, -50.0, 0.0) },
-            disable = { move = true, car = true, combat = true },
-            usetime = 2500,
-        }
     },
 
     ['burger'] = {


### PR DESCRIPTION
## Description

- We currently have an item in qbx_ambulancejob/qbx_medical which uses the bandage item and this conflicts with that.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
