### PR TITLE
fix(cfg): remove semicolon from comments

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -89,12 +89,12 @@ exec permissions.cfg
 # Type: string
 # set sv_master1 "" # Uncomment to mark the server as private
 
-# Variance is how likely the user's id will change for a given provider (i.e. 'steam', 'ip', or 'license'). As an integer from 1-5 (default 5); from least to most likely to change.
+# Variance is how likely the user's id will change for a given provider (i.e. 'steam', 'ip', or 'license'). As an integer from 1-5 (default 5), from least to most likely to change.
 # Default: 5
 # Type: int
 set sv_authMaxVariance 5
 
-# Trust is how unlikely it is for the user's identity to be spoofed by a malicious client. As an integer from 1-5 (default 1); from least to most trustworthy.
+# Trust is how unlikely it is for the user's identity to be spoofed by a malicious client. As an integer from 1-5 (default 1), from least to most trustworthy.
 # (5 being a method such as external three-way authentication).
 # Default: 1
 # Type: int

--- a/voice.cfg
+++ b/voice.cfg
@@ -56,7 +56,7 @@ setr voice_defaultRadioVolume 60
 # Type: integer
 setr voice_defaultCallVolume 80
 
-# Default proximity voice value when player joins server. (Voice Modes; 1:Whisper, 2:Normal, 3:Shouting)
+# Default proximity voice value when player joins server. (1:Whisper, 2:Normal, 3:Shouting)
 # Default: 2
 # Type: integer
 setr voice_defaultVoiceMode 2


### PR DESCRIPTION
## Description

Seems like semicolons on comments are considered as end of comment/line which tries to execute the next word as a command

![image](https://github.com/user-attachments/assets/0fb953af-d71d-4557-b717-a42181b241d6)
![image](https://github.com/user-attachments/assets/70d3373e-ee6b-4159-b3d6-89759ffec52e)


## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
