### PR TITLE
feat(recipe): include misc.cfg in lean and stable recipes

### DIFF
--- a/qbox-lean.yaml
+++ b/qbox-lean.yaml
@@ -29,6 +29,10 @@ tasks:
     dest: ./voice.cfg
 
   - action: move_path
+    src: ./tmp/qbox/misc.cfg
+    dest: ./misc.cfg
+
+  - action: move_path
     src: ./tmp/qbox/myLogo.png
     dest: ./myLogo.png
 

--- a/qbox-stable.yaml
+++ b/qbox-stable.yaml
@@ -29,6 +29,10 @@ tasks:
     dest: ./voice.cfg
 
   - action: move_path
+    src: ./tmp/qbox/misc.cfg
+    dest: ./misc.cfg
+
+  - action: move_path
     src: ./tmp/qbox/myLogo.png
     dest: ./myLogo.png
 


### PR DESCRIPTION
## Description

Includes misc.cfg to both Lean & Stable recipes

(_associated warning on a fresh deploy:_  `[cmd] No such config file: misc.cfg`)

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
