### PR TITLE
Remove screenshot-basic as it isn't needed

### DIFF
--- a/qbox-lean.yaml
+++ b/qbox-lean.yaml
@@ -60,11 +60,11 @@ tasks:
     src: https://github.com/qbox-project/safecracker
 
   - action: download_file
-    path: ./tmp/screenshot-basic.zip
-    url: https://github.com/project-error/screenshot-basic/releases/latest/download/screenshot-basic.zip
+    path: ./tmp/screencapture.zip
+    url: https://github.com/itschip/screencapture/releases/latest/download/screencapture.zip
   - action: unzip
-    dest: ./resources/[standalone]/screenshot-basic
-    src: ./tmp/screenshot-basic.zip
+    dest: ./resources/[standalone]/
+    src: ./tmp/screencapture.zip
 
   - action: download_github
     dest: ./resources/[standalone]/mhacking

--- a/qbox-stable.yaml
+++ b/qbox-stable.yaml
@@ -60,11 +60,11 @@ tasks:
     src: https://github.com/qbox-project/safecracker
 
   - action: download_file
-    path: ./tmp/screenshot-basic.zip
-    url: https://github.com/project-error/screenshot-basic/releases/latest/download/screenshot-basic.zip
+    path: ./tmp/screencapture.zip
+    url: https://github.com/itschip/screencapture/releases/latest/download/screencapture.zip
   - action: unzip
-    dest: ./resources/[standalone]/screenshot-basic
-    src: ./tmp/screenshot-basic.zip
+    dest: ./resources/[standalone]/
+    src: ./tmp/screencapture.zip
 
   - action: download_github
     dest: ./resources/[standalone]/mhacking

--- a/qbox.yaml
+++ b/qbox.yaml
@@ -66,13 +66,6 @@ tasks:
     dest: ./resources/[standalone]
     src: ./tmp/screencapture.zip
 
-  - action: download_file
-    path: ./tmp/screenshot-basic.zip
-    url: https://github.com/project-error/screenshot-basic/releases/latest/download/screenshot-basic.zip
-  - action: unzip
-    dest: ./resources/[standalone]/screenshot-basic
-    src: ./tmp/screenshot-basic.zip
-
   - action: download_github
     dest: ./resources/[standalone]/mhacking
     ref: main


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Screenshot basic is old, outdated and insecure, screencapture has a bridge for screenshot-basic while being faster, more optimised and genuinely maintained, there is no point of having 2 capture resources inside of qbox (especially when there is a bridge :) )
## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x ] My pull request fits the contribution guidelines & code conventions.
