### PR TITLE
Replace qbx_density with 7_popmanager

### DIFF
--- a/qbox.yaml
+++ b/qbox.yaml
@@ -124,6 +124,11 @@ tasks:
     dest: ./resources/[standalone]
     src: ./tmp/Renewed-Weathersync.zip
 
+  - action: download_github
+    dest: ./resources/[standalone]/7_popmanager
+    ref: main
+    src: https://github.com/squarerootof49/7_popmanager
+
   - action: download_file
     path: ./tmp/xt-prison.zip
     url: https://github.com/xT-Development/xt-prison/releases/latest/download/xt-prison.zip
@@ -421,11 +426,6 @@ tasks:
     dest: ./resources/[qbx]/qbx_fireworks
     ref: main
     src: https://github.com/Qbox-project/qbx_fireworks
-
-  - action: download_github
-    dest: ./resources/[qbx]/qbx_density
-    ref: main
-    src: https://github.com/Qbox-project/qbx_density
 
   - action: download_github
     dest: ./resources/[qbx]/qbx_customs

--- a/qbox.yaml
+++ b/qbox.yaml
@@ -70,6 +70,12 @@ tasks:
     dest: ./resources/[standalone]/mhacking
     ref: main
     src: https://github.com/qbox-project/mhacking
+    
+    # Bridge for mm_radio
+  - action: download_github
+    dest: ./resources/[standalone]/bl_bridge
+    ref: main
+    src: https://github.com/Byte-Labs-Studio/bl_bridge
 
   - action: waste_time # prevent github throttling
     seconds: 10

--- a/voice.cfg
+++ b/voice.cfg
@@ -100,7 +100,17 @@ setr voice_allowSetIntent 1
 # Default: 0
 # Type: integer
 setr voice_debugMode 0
-
+# =========================================================
+# ================= Radio Bridge Settings =================
+# =========================================================
+setr bl:framework 'qbx' 
+setr bl:inventory 'ox'
+setr bl:context 'ox'
+setr bl:target 'ox'
+setr bl:progressbar 'ox'
+setr bl:radial 'ox'
+setr bl:notify 'ox'
+setr bl:textui 'ox'
 # =========================================================
 # ================= External Mumble Server ================
 # =========================================================


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
qbx_density isnt maintained as well as 7_popmanager, and has less features,
this is much better for managing density, and is completely loopless.

-- I have been provided express permission to use this resource by seven (original creator) https://r2.fivemanage.com/image/GcQhBLVtku9E.png
## Checklist

<!-- Put an x inside the [x] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
