### PR TITLE
Add progressPropLimit setting to ox.cfg

### DIFF
--- a/ox.cfg
+++ b/ox.cfg
@@ -9,6 +9,9 @@ setr ox:primaryShade 8
 # Allow users to select their locales using /ox_lib (0 = disabled, 1 = enabled)
 setr ox:userLocales 0
 
+# Defines the maximum number of spawned props for progressbar
+setr ox:progressPropLimit 2
+
 # Load specific language file from data/locales
 setr ox:locale "en"
 


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Added a setting to define the maximum number of spawned props for the progress bar. as in https://coxdocs.dev/ox_lib

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x ] My pull request fits the contribution guidelines & code conventions.
