### PR TITLE
fix: enable secure network event defaults

### DIFF
--- a/misc.cfg
+++ b/misc.cfg
@@ -26,12 +26,12 @@
 # Used to block REQUEST_CONTROL_EVENT routing based on a configurable policy. Find more info here: https://docs.fivem.net/docs/server-manual/server-commands/#sv_filterrequestcontrol-mode
 # Default: 0
 # Type: int
-# set sv_filterRequestControl 0
+set sv_filterRequestControl 1
 
 # Used if sv_filterRequestControl is set to 1 or 3. Allows you to set after how long (based on entity creation time in milliseconds) an entity should be blocked from a REQUEST_CONTROL_EVENT
 # Default: 30000
 # Type: int
-# set sv_filterRequestControlSettleTimer 30000
+set sv_filterRequestControlSettleTimer 30000
 
 # Used to prevent users from using modified client files. See: https://docs.fivem.net/docs/server-manual/server-commands/#sv_purelevel-level
 # Default: 0
@@ -41,17 +41,17 @@
 # Used to prevent users from routing NETWORK_PLAY_SOUND_EVENT through the server, which is commonly used by malicious actors. This is set to true by default (allow routing)
 # Default: true
 # Type: boolean
-# set sv_enableNetworkedSounds true
+set sv_enableNetworkedSounds false
 
 # Enabling it (by setting it to true), will allow users to route REQUEST_PHONE_EXPLOSION_EVENT through the server. The main drawback behind enabling this, is that it can also be used by malicious actors.
 # Default: false
 # Type: boolean
-# set sv_enablePhoneExplosions false
+set sv_enableNetworkedPhoneExplosions false
 
 # A boolean console variable introduced in server version 8540 that can be used to prevent users from routing SCRIPT_ENTITY_STATE_CHANGE_EVENT through the server, which is commonly used by malicious actors.
 # Default: true
 # Type: boolean
-# set sv_enableNetworkedScriptEntityStates true
+set sv_enableNetworkedScriptEntityStates false
 
 # Any profile settings can be enforced by the server by using setr to replicate it to the client.
 # All possible settings can be found in your own FiveM installation at "C:\Users\user\AppData\Roaming\CitizenFX\fivem.cfg"


### PR DESCRIPTION
## Summary

- enable request-control filtering with the documented settle timer
- disable network-routed sounds, phone explosions, and script entity state changes
- use the current `sv_enableNetworkedPhoneExplosions` convar name

## Security impact

The recipe now ships safer defaults for commonly abused routed network events while retaining explicit configuration points for operators who need compatibility overrides.

## Validation

- `git diff --check`
- convar names checked against the Cfx.re server command documentation
- GitHub security checks will run on this draft